### PR TITLE
Refine mind map editing interface

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2,90 +2,90 @@
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  background: linear-gradient(180deg, #f8fafc 0%, #e2e8f0 100%);
+  background: radial-gradient(circle at top, #f8fafc 0%, #e2e8f0 100%);
   color: #0f172a;
 }
 
-.app-header {
+.top-bar {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 24px;
-  padding: 32px 40px 24px;
-  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  gap: 32px;
+  padding: 28px 48px 20px;
 }
 
-.app-tag {
+.top-tag {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  padding: 4px 12px;
+  padding: 6px 16px;
   border-radius: 999px;
-  background: rgba(59, 130, 246, 0.12);
+  background: rgba(59, 130, 246, 0.14);
   color: #1d4ed8;
   font-weight: 600;
   font-size: 0.85rem;
-  margin-bottom: 12px;
+  margin: 0 0 12px;
 }
 
-.app-header h1 {
+.top-title {
+  margin: 0;
   font-size: 2.75rem;
   font-weight: 700;
-  margin: 0 0 8px;
   letter-spacing: -0.02em;
 }
 
-.app-subtitle {
-  margin: 0;
-  max-width: 560px;
-  font-size: 1.05rem;
-  line-height: 1.6;
-  color: rgba(15, 23, 42, 0.8);
+.top-subtitle {
+  margin: 10px 0 0;
+  max-width: 520px;
+  line-height: 1.55;
+  color: rgba(15, 23, 42, 0.75);
 }
 
-.header-stats {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 18px;
-}
-
-.header-stats > div {
-  background: white;
-  border-radius: 18px;
-  padding: 18px 24px;
-  min-width: 140px;
-  box-shadow: 0 18px 35px rgba(15, 23, 42, 0.08);
-  text-align: center;
-}
-
-.stat-value {
-  display: block;
-  font-size: 2rem;
+.top-subtitle strong {
   font-weight: 700;
 }
 
-.stat-label {
-  display: block;
+.top-metrics {
+  display: flex;
+  gap: 18px;
+  padding-top: 8px;
+}
+
+.top-metrics > div {
+  background: rgba(255, 255, 255, 0.75);
+  border-radius: 20px;
+  padding: 16px 22px;
+  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.12);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 120px;
+}
+
+.metric-value {
+  font-size: 1.8rem;
+  font-weight: 700;
+}
+
+.metric-label {
   font-size: 0.9rem;
   color: rgba(15, 23, 42, 0.65);
 }
 
-.app-body {
+.workspace {
   flex: 1;
   display: flex;
-  gap: 32px;
-  padding: 32px 40px 48px;
-  box-sizing: border-box;
+  padding: 0 48px 48px;
 }
 
 .canvas-wrapper {
   position: relative;
-  flex: 1 1 auto;
-  background: radial-gradient(circle at top, rgba(148, 163, 184, 0.22), rgba(148, 163, 184, 0.08));
-  border-radius: 28px;
+  flex: 1;
+  background: radial-gradient(circle at center, rgba(148, 163, 184, 0.18), rgba(148, 163, 184, 0.05));
+  border-radius: 36px;
   border: 1px solid rgba(100, 116, 139, 0.18);
   overflow: hidden;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 25px 45px rgba(15, 23, 42, 0.15);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6), 0 30px 60px rgba(15, 23, 42, 0.18);
 }
 
 .mindmap-canvas {
@@ -96,12 +96,13 @@
 
 .mindmap-connection {
   stroke: rgba(15, 23, 42, 0.25);
-  stroke-width: 2.5;
+  stroke-width: 3;
   stroke-linecap: round;
 }
 
 .mindmap-node {
   cursor: pointer;
+  transition: transform 0.2s ease;
 }
 
 .mindmap-node-card {
@@ -110,164 +111,167 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 16px;
-  border-radius: 20px;
+  padding: 18px 20px;
+  border-radius: 24px;
   background: white;
   color: #0f172a;
   font-weight: 600;
-  font-size: 1rem;
+  font-size: 1.05rem;
   text-align: center;
   line-height: 1.3;
-  box-shadow: 0 18px 30px rgba(15, 23, 42, 0.14);
-  border: 2px solid transparent;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, border 0.2s ease;
-}
-
-.mindmap-node-card.is-root {
-  background: linear-gradient(135deg, #2563eb 0%, #3b82f6 100%);
-  color: white;
+  border: 3px solid transparent;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.18);
+  transition: border 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+  filter: url(#node-shadow);
 }
 
 .mindmap-node-card.is-selected {
-  transform: translateY(-2px) scale(1.02);
-  border-color: rgba(37, 99, 235, 0.7);
-  box-shadow: 0 20px 35px rgba(37, 99, 235, 0.22);
+  border-color: #38bdf8;
+  box-shadow: 0 25px 50px rgba(14, 165, 233, 0.25);
 }
 
-.canvas-hint {
-  position: absolute;
-  bottom: 20px;
-  left: 24px;
-  padding: 10px 16px;
-  background: rgba(15, 23, 42, 0.75);
-  color: white;
-  border-radius: 999px;
-  font-size: 0.9rem;
-  letter-spacing: 0.01em;
+.mindmap-node-card.is-root {
+  border-color: #2563eb;
 }
 
-.side-panel {
-  width: 340px;
-  flex: 0 0 auto;
-  background: white;
-  border-radius: 28px;
-  padding: 28px;
-  box-shadow: 0 24px 45px rgba(15, 23, 42, 0.12);
-  border: 1px solid rgba(148, 163, 184, 0.26);
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
-}
-
-.panel-title {
-  margin: 0;
-  font-size: 1.5rem;
-}
-
-.panel-description {
-  margin: 0;
-  color: rgba(15, 23, 42, 0.7);
-  line-height: 1.6;
-}
-
-.panel-section {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.panel-label {
-  font-weight: 600;
-  font-size: 0.95rem;
-}
-
-.panel-input {
+.node-input {
   width: 100%;
-  padding: 12px 14px;
-  border-radius: 14px;
-  border: 1px solid rgba(148, 163, 184, 0.45);
-  background: rgba(241, 245, 249, 0.6);
-  font-size: 0.95rem;
-  transition: border 0.2s ease, box-shadow 0.2s ease;
-}
-
-.panel-input:focus {
-  outline: none;
-  border-color: rgba(59, 130, 246, 0.8);
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25);
-  background: white;
-}
-
-.panel-inline {
-  display: flex;
-  gap: 12px;
-}
-
-.primary-button,
-.danger-button {
   border: none;
-  border-radius: 14px;
-  padding: 12px 20px;
+  background: transparent;
+  font: inherit;
+  text-align: center;
+  color: inherit;
+  padding: 0;
+  outline: none;
+}
+
+.node-input::placeholder {
+  color: rgba(15, 23, 42, 0.45);
+}
+
+.node-label {
+  display: inline-block;
+  padding: 0 4px;
+}
+
+.node-label.is-placeholder {
+  color: rgba(15, 23, 42, 0.45);
+  font-weight: 500;
+}
+
+.floating-toolbar {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 18px 35px rgba(15, 23, 42, 0.18);
+  border: 1px solid rgba(148, 163, 184, 0.26);
+  backdrop-filter: blur(4px);
+}
+
+.toolbar-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: none;
+  background: transparent;
+  color: rgba(15, 23, 42, 0.8);
+  font-size: 0.85rem;
   font-weight: 600;
-  font-size: 0.95rem;
+  padding: 6px 10px;
+  border-radius: 12px;
   cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  transition: background 0.2s ease, color 0.2s ease;
 }
 
-.primary-button {
-  background: linear-gradient(135deg, #2563eb 0%, #3b82f6 100%);
+.toolbar-button:hover:not(:disabled) {
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+}
+
+.toolbar-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.toolbar-button svg {
+  width: 16px;
+  height: 16px;
+}
+
+.quick-add {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.quick-add-button {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: none;
+  background: linear-gradient(135deg, #38bdf8 0%, #0ea5e9 100%);
   color: white;
-  box-shadow: 0 15px 30px rgba(37, 99, 235, 0.25);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: 0 18px 35px rgba(14, 165, 233, 0.35);
+  transition: transform 0.18s ease;
 }
 
-.primary-button:hover {
+.quick-add-button:hover {
   transform: translateY(-1px);
 }
 
-.danger-button {
-  background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
+.quick-add-button svg {
+  width: 18px;
+  height: 18px;
+}
+
+.canvas-overlay {
+  position: absolute;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.overlay-tip {
+  background: rgba(15, 23, 42, 0.75);
   color: white;
-  box-shadow: 0 15px 30px rgba(239, 68, 68, 0.2);
-}
-
-.danger-button:disabled {
-  cursor: not-allowed;
-  background: rgba(148, 163, 184, 0.4);
-  box-shadow: none;
-}
-
-.panel-hint {
-  margin: 0;
+  padding: 10px 16px;
+  border-radius: 999px;
   font-size: 0.85rem;
-  color: rgba(15, 23, 42, 0.55);
+  letter-spacing: 0.01em;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.2);
 }
 
-.panel-subtitle {
-  margin: 0;
-  font-size: 1.05rem;
-}
-
-.tips-list {
-  margin: 0;
-  padding-left: 18px;
-  color: rgba(15, 23, 42, 0.7);
-  line-height: 1.5;
-}
-
-@media (max-width: 1100px) {
-  .app-header {
+@media (max-width: 1024px) {
+  .top-bar {
     flex-direction: column;
   }
 
-  .app-body {
-    flex-direction: column;
+  .workspace {
+    padding: 0 24px 32px;
+  }
+}
+
+@media (max-width: 720px) {
+  .top-bar {
+    padding: 24px;
   }
 
-  .side-panel {
-    width: 100%;
+  .workspace {
+    padding: 0 16px 24px;
   }
 
   .canvas-wrapper {
-    min-height: 560px;
+    border-radius: 24px;
+  }
+
+  .floating-toolbar {
+    transform: scale(0.9);
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,12 +1,12 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import './App.css'
 
-const LEVEL_SPACING = 180
-const NODE_WIDTH = 160
-const NODE_HEIGHT = 72
+const LEVEL_SPACING = 220
+const NODE_WIDTH = 220
+const NODE_HEIGHT = 88
 
 const INITIAL_NODES = [
-  { id: 'root', label: 'Sujet principal', parentId: null },
+  { id: 'root', label: 'Ma carte mentale', parentId: null },
   { id: 'node-1', label: 'Idée clé #1', parentId: 'root' },
   { id: 'node-2', label: 'Idée clé #2', parentId: 'root' },
 ]
@@ -68,10 +68,65 @@ function computeLayout(nodes) {
   return positions
 }
 
+function getBranchToDelete(nodes, selectedId) {
+  const toDelete = new Set([selectedId])
+  const stack = [selectedId]
+
+  while (stack.length > 0) {
+    const current = stack.pop()
+    nodes
+      .filter((node) => node.parentId === current)
+      .forEach((child) => {
+        if (!toDelete.has(child.id)) {
+          toDelete.add(child.id)
+          stack.push(child.id)
+        }
+      })
+  }
+
+  return toDelete
+}
+
+function IconPlus() {
+  return (
+    <svg viewBox="0 0 20 20" aria-hidden="true">
+      <path d="M10 4v12M4 10h12" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+    </svg>
+  )
+}
+
+function IconTrash() {
+  return (
+    <svg viewBox="0 0 20 20" aria-hidden="true">
+      <path
+        d="M4.5 6.5h11M8.5 3.5h3m-4 3v9m5-9v9m-8 0h11a1 1 0 0 1-1 1h-9a1 1 0 0 1-1-1z"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
+function IconCenter() {
+  return (
+    <svg viewBox="0 0 20 20" aria-hidden="true">
+      <path
+        d="M3 10h4m6 0h4M10 3v4m0 6v4m-4-4h8m-4-4h.01"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
 function App() {
   const [nodes, setNodes] = useState(INITIAL_NODES)
   const [selectedId, setSelectedId] = useState('root')
-  const [draftLabel, setDraftLabel] = useState('')
+  const [draftLabel, setDraftLabel] = useState(INITIAL_NODES[0].label)
   const idCounter = useRef(nextIdFromInitial)
 
   const rootNode = useMemo(
@@ -92,91 +147,111 @@ function App() {
     return node ?? rootNode
   }, [nodes, selectedId, rootNode])
 
-  const updateSelectedLabel = (label) => {
-    if (!selectedNode) return
-    setNodes((prev) =>
-      prev.map((node) =>
-        node.id === selectedNode.id
-          ? {
-              ...node,
-              label,
-            }
-          : node,
-      ),
-    )
-  }
+  useEffect(() => {
+    if (selectedNode) {
+      setDraftLabel(selectedNode.label)
+    } else {
+      setDraftLabel('')
+    }
+  }, [selectedNode?.id])
 
-  const addChild = () => {
+  const updateSelectedLabel = useCallback(
+    (label) => {
+      if (!selectedNode) return
+      setDraftLabel(label)
+      setNodes((prev) =>
+        prev.map((node) =>
+          node.id === selectedNode.id
+            ? {
+                ...node,
+                label,
+              }
+            : node,
+        ),
+      )
+    },
+    [selectedNode],
+  )
+
+  const addChild = useCallback(() => {
     if (!selectedNode) return
-    const trimmedLabel = draftLabel.trim()
-    const label = trimmedLabel.length > 0 ? trimmedLabel : `Nouvelle idée ${idCounter.current}`
 
     const newNode = {
       id: `node-${idCounter.current}`,
-      label,
+      label: '',
       parentId: selectedNode.id,
     }
 
     idCounter.current += 1
     setNodes((prev) => [...prev, newNode])
-    setDraftLabel('')
     setSelectedId(newNode.id)
-  }
+    setDraftLabel('')
+  }, [selectedNode])
 
-  const removeSelectedBranch = () => {
+  const removeSelectedBranch = useCallback(() => {
     if (!selectedNode || selectedNode.id === rootNode?.id) return
 
-    const toDelete = new Set([selectedNode.id])
-    const queue = [selectedNode.id]
-
-    while (queue.length > 0) {
-      const current = queue.pop()
-      nodes
-        .filter((node) => node.parentId === current)
-        .forEach((child) => {
-          toDelete.add(child.id)
-          queue.push(child.id)
-        })
-    }
-
+    const toDelete = getBranchToDelete(nodes, selectedNode.id)
     setNodes((prev) => prev.filter((node) => !toDelete.has(node.id)))
     if (rootNode) {
       setSelectedId(rootNode.id)
     }
-  }
+  }, [nodes, rootNode, selectedNode])
 
-  const totalIdeas = nodes.length
-  const levelCount = Math.max(...nodes.map((node) => positions[node.id]?.depth ?? 0), 0)
+  const recentre = useCallback(() => {
+    if (!rootNode) return
+    setSelectedId(rootNode.id)
+  }, [rootNode])
+
+  const handleCanvasClick = useCallback(() => {
+    if (rootNode) {
+      setSelectedId(rootNode.id)
+    }
+  }, [rootNode])
+
+  const handleNodeKeyDown = useCallback(
+    (event) => {
+      if (event.key === 'Enter' || event.key === 'Tab') {
+        event.preventDefault()
+        addChild()
+      }
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'backspace') {
+        event.preventDefault()
+        removeSelectedBranch()
+      }
+    },
+    [addChild, removeSelectedBranch],
+  )
 
   return (
     <div className="app">
-      <header className="app-header">
+      <header className="top-bar">
         <div>
-          <p className="app-tag">Proof of Concept</p>
-          <h1>OpenMindMap</h1>
-          <p className="app-subtitle">
-            Concevez rapidement une carte mentale interactive. Cette version de démonstration se concentre sur la
-            création, l&apos;organisation et l&apos;édition de vos idées essentielles.
+          <p className="top-tag">POC interactif</p>
+          <h1 className="top-title">OpenMindMap</h1>
+          <p className="top-subtitle">
+            Ajoutez et renommez vos idées directement sur la carte. Appuyez sur <strong>Entrée</strong> ou
+            <strong> Tab</strong> pour créer une idée secondaire.
           </p>
         </div>
-        <div className="header-stats">
+        <div className="top-metrics">
           <div>
-            <span className="stat-value">{totalIdeas}</span>
-            <span className="stat-label">idées</span>
+            <span className="metric-value">{nodes.length}</span>
+            <span className="metric-label">idées</span>
           </div>
           <div>
-            <span className="stat-value">{levelCount + 1}</span>
-            <span className="stat-label">niveaux</span>
+            <span className="metric-value">{Math.max(...nodes.map((node) => positions[node.id]?.depth ?? 0), 0) + 1}</span>
+            <span className="metric-label">niveaux</span>
           </div>
         </div>
       </header>
 
-      <main className="app-body">
-        <section className="canvas-wrapper">
-          <svg className="mindmap-canvas" viewBox="-640 -380 1280 760">
+      <main className="workspace">
+        <section className="canvas-wrapper" onClick={handleCanvasClick}>
+          <svg className="mindmap-canvas" viewBox="-720 -480 1440 960">
             <defs>
               <filter id="node-shadow" x="-20%" y="-20%" width="140%" height="140%">
-                <feDropShadow dx="0" dy="12" stdDeviation="12" floodColor="rgba(15, 23, 42, 0.18)" />
+                <feDropShadow dx="0" dy="14" stdDeviation="14" floodColor="rgba(15, 23, 42, 0.22)" />
               </filter>
             </defs>
 
@@ -204,6 +279,7 @@ function App() {
               if (!nodePos) return null
               const isSelected = node.id === selectedNode?.id
               const isRoot = node.id === rootNode?.id
+              const displayLabel = node.label.trim().length > 0 ? node.label : 'Nommez cette idée'
 
               return (
                 <g
@@ -215,100 +291,98 @@ function App() {
                     setSelectedId(node.id)
                   }}
                 >
-                  <foreignObject
-                    x={-NODE_WIDTH / 2}
-                    y={-NODE_HEIGHT / 2}
-                    width={NODE_WIDTH}
-                    height={NODE_HEIGHT}
-                  >
+                  {isSelected && (
+                    <foreignObject
+                      x={-110}
+                      y={-NODE_HEIGHT / 2 - 56}
+                      width={220}
+                      height={48}
+                      className="toolbar-wrapper"
+                    >
+                      <div className="floating-toolbar" xmlns="http://www.w3.org/1999/xhtml">
+                        <button type="button" className="toolbar-button" onClick={(event) => {
+                          event.stopPropagation()
+                          addChild()
+                        }}
+                        >
+                          <IconPlus />
+                          <span>Ajouter</span>
+                        </button>
+                        <button
+                          type="button"
+                          className="toolbar-button"
+                          onClick={(event) => {
+                            event.stopPropagation()
+                            recentre()
+                          }}
+                        >
+                          <IconCenter />
+                          <span>Centre</span>
+                        </button>
+                        <button
+                          type="button"
+                          className="toolbar-button"
+                          disabled={isRoot}
+                          onClick={(event) => {
+                            event.stopPropagation()
+                            removeSelectedBranch()
+                          }}
+                        >
+                          <IconTrash />
+                          <span>Suppr.</span>
+                        </button>
+                      </div>
+                    </foreignObject>
+                  )}
+
+                  <foreignObject x={-NODE_WIDTH / 2} y={-NODE_HEIGHT / 2} width={NODE_WIDTH} height={NODE_HEIGHT}>
                     <div
                       className={`mindmap-node-card ${isSelected ? 'is-selected' : ''} ${isRoot ? 'is-root' : ''}`}
-                      role="button"
-                      tabIndex={0}
+                      xmlns="http://www.w3.org/1999/xhtml"
                     >
-                      <span>{node.label}</span>
+                      {isSelected ? (
+                        <input
+                          className="node-input"
+                          autoFocus
+                          value={draftLabel}
+                          placeholder="Nommez cette idée"
+                          onChange={(event) => updateSelectedLabel(event.target.value)}
+                          onClick={(event) => event.stopPropagation()}
+                          onKeyDown={handleNodeKeyDown}
+                        />
+                      ) : (
+                        <span className={`node-label ${displayLabel === node.label ? '' : 'is-placeholder'}`}>
+                          {displayLabel}
+                        </span>
+                      )}
                     </div>
                   </foreignObject>
+
+                  {isSelected && (
+                    <foreignObject x={NODE_WIDTH / 2 + 12} y={-22} width={44} height={44}>
+                      <div className="quick-add" xmlns="http://www.w3.org/1999/xhtml">
+                        <button
+                          type="button"
+                          className="quick-add-button"
+                          onClick={(event) => {
+                            event.stopPropagation()
+                            addChild()
+                          }}
+                        >
+                          <IconPlus />
+                        </button>
+                      </div>
+                    </foreignObject>
+                  )}
                 </g>
               )
             })}
           </svg>
-          <div className="canvas-hint">Cliquez sur un nœud pour le sélectionner et le modifier.</div>
+
+          <div className="canvas-overlay">
+            <div className="overlay-tip">Cliquez sur la carte pour sélectionner un nœud. Ctrl + Retour arrière pour supprimer.</div>
+          </div>
         </section>
-
-        <aside className="side-panel">
-          <h2 className="panel-title">Panneau de contrôle</h2>
-          <p className="panel-description">
-            Ajoutez de nouvelles branches ou renommez une idée pour structurer rapidement votre projet.
-          </p>
-
-          <div className="panel-section">
-            <label className="panel-label" htmlFor="selected-label">
-              Nom de l&apos;idée sélectionnée
-            </label>
-            <input
-              id="selected-label"
-              className="panel-input"
-              type="text"
-              value={selectedNode?.label ?? ''}
-              onChange={(event) => updateSelectedLabel(event.target.value)}
-            />
-            <p className="panel-hint">
-              {selectedNode?.id === rootNode?.id
-                ? 'Il s’agit du sujet central de votre carte.'
-                : 'Appuyez sur Entrée pour enregistrer rapidement le nouveau titre.'}
-            </p>
-          </div>
-
-          <div className="panel-section">
-            <label className="panel-label" htmlFor="new-idea">
-              Ajouter une nouvelle idée liée
-            </label>
-            <div className="panel-inline">
-              <input
-                id="new-idea"
-                className="panel-input"
-                type="text"
-                placeholder="Nom de la nouvelle idée"
-                value={draftLabel}
-                onChange={(event) => setDraftLabel(event.target.value)}
-                onKeyDown={(event) => {
-                  if (event.key === 'Enter') {
-                    event.preventDefault()
-                    addChild()
-                  }
-                }}
-              />
-              <button type="button" className="primary-button" onClick={addChild}>
-                Ajouter
-              </button>
-            </div>
-            <p className="panel-hint">
-              La branche sera reliée à « {selectedNode?.label ?? '...'} ».
-            </p>
-          </div>
-
-          <div className="panel-section">
-            <button
-              type="button"
-              className="danger-button"
-              onClick={removeSelectedBranch}
-              disabled={!selectedNode || selectedNode.id === rootNode?.id}
-            >
-              Supprimer la branche
-            </button>
-            <p className="panel-hint">Disponible uniquement pour les branches secondaires.</p>
-          </div>
-
-          <div className="panel-section">
-            <h3 className="panel-subtitle">Astuces rapides</h3>
-            <ul className="tips-list">
-              <li>Sélectionnez un nœud pour le renommer instantanément.</li>
-              <li>Utilisez le bouton « Ajouter » pour créer des idées filles.</li>
-              <li>Supprimez une branche pour repartir d&apos;une nouvelle idée.</li>
-            </ul>
-          </div>
-        </aside>
       </main>
     </div>
   )


### PR DESCRIPTION
## Summary
- expand the mind map canvas to occupy the screen with inline editing of nodes
- add a floating action toolbar and quick add control to create or remove ideas directly on the map
- refresh the styling to match the lightweight reference UI while keeping key metrics visible

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de743d834c8321b6086900dfaec299