### PR TITLE
Make mind map canvas full screen

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,96 +1,26 @@
 .app {
-  min-height: 100vh;
+  height: 100vh;
+  width: 100vw;
   display: flex;
-  flex-direction: column;
   background: radial-gradient(circle at top, #f8fafc 0%, #e2e8f0 100%);
   color: #0f172a;
-}
-
-.top-bar {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 32px;
-  padding: 28px 48px 20px;
-}
-
-.top-tag {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 16px;
-  border-radius: 999px;
-  background: rgba(59, 130, 246, 0.14);
-  color: #1d4ed8;
-  font-weight: 600;
-  font-size: 0.85rem;
-  margin: 0 0 12px;
-}
-
-.top-title {
-  margin: 0;
-  font-size: 2.75rem;
-  font-weight: 700;
-  letter-spacing: -0.02em;
-}
-
-.top-subtitle {
-  margin: 10px 0 0;
-  max-width: 520px;
-  line-height: 1.55;
-  color: rgba(15, 23, 42, 0.75);
-}
-
-.top-subtitle strong {
-  font-weight: 700;
-}
-
-.top-metrics {
-  display: flex;
-  gap: 18px;
-  padding-top: 8px;
-}
-
-.top-metrics > div {
-  background: rgba(255, 255, 255, 0.75);
-  border-radius: 20px;
-  padding: 16px 22px;
-  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.12);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  min-width: 120px;
-}
-
-.metric-value {
-  font-size: 1.8rem;
-  font-weight: 700;
-}
-
-.metric-label {
-  font-size: 0.9rem;
-  color: rgba(15, 23, 42, 0.65);
-}
-
-.workspace {
-  flex: 1;
-  display: flex;
-  padding: 0 48px 48px;
+  overflow: hidden;
 }
 
 .canvas-wrapper {
   position: relative;
   flex: 1;
   background: radial-gradient(circle at center, rgba(148, 163, 184, 0.18), rgba(148, 163, 184, 0.05));
-  border-radius: 36px;
-  border: 1px solid rgba(100, 116, 139, 0.18);
+  border-radius: 0;
+  border: none;
   overflow: hidden;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6), 0 30px 60px rgba(15, 23, 42, 0.18);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
 }
 
 .mindmap-canvas {
   width: 100%;
   height: 100%;
+  display: block;
   cursor: pointer;
 }
 
@@ -246,32 +176,4 @@
   font-size: 0.85rem;
   letter-spacing: 0.01em;
   box-shadow: 0 20px 40px rgba(15, 23, 42, 0.2);
-}
-
-@media (max-width: 1024px) {
-  .top-bar {
-    flex-direction: column;
-  }
-
-  .workspace {
-    padding: 0 24px 32px;
-  }
-}
-
-@media (max-width: 720px) {
-  .top-bar {
-    padding: 24px;
-  }
-
-  .workspace {
-    padding: 0 16px 24px;
-  }
-
-  .canvas-wrapper {
-    border-radius: 24px;
-  }
-
-  .floating-toolbar {
-    transform: scale(0.9);
-  }
 }


### PR DESCRIPTION
## Summary
- remove the landing header and metrics so only the mind map remains
- expand the canvas styles to fill the full viewport without scrollbars
- keep the floating toolbar focused on the delete action for selected nodes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de7806117c8321b9ddb11f8a347a0f