### PR TITLE
Add local persistence and serialization utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,15 @@ L’accent est mis sur :
 
 ---
 
+## 💾 Sauvegarde locale & formats d'échange
+
+L'application conserve automatiquement la dernière version de votre carte mentale dans le navigateur via `localStorage`. À chaque modification, la structure des nœuds est sérialisée et rechargée lors du prochain démarrage. Vous pouvez à tout moment déclencher une exportation manuelle dans le panneau d'actions de l'interface.
+
+Formats supportés :
+
+- **JSON** (`openmindmap.json`) : représente directement la structure interne (`id`, `label`, `children`). C'est le format de sauvegarde recommandé et celui utilisé dans `localStorage`.
+- **OPML** (`openmindmap.opml`) : compatible avec la majorité des logiciels de mind mapping. Chaque nœud est exporté sous forme d'élément `<outline>` avec les attributs `text` (titre) et `id`. À l'import, la hiérarchie OPML est convertie vers la structure interne de l'application.
+
 ## 📦 Installation (MVP local)
 
 ```bash

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,142 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  deserializeFromJSON,
+  deserializeFromOPML,
+  serializeToJSON,
+  serializeToOPML,
+} from "./utils/serialization";
+
+const STORAGE_KEY = "openmindmap:nodes";
+
+const INITIAL_NODES = [
+  {
+    id: "root",
+    label: "Idée principale",
+    children: [
+      { id: "node-1", label: "Sous-idée A", children: [] },
+      { id: "node-2", label: "Sous-idée B", children: [] },
+    ],
+  },
+];
+
+const DOWNLOAD_FILENAME_JSON = "openmindmap.json";
+const DOWNLOAD_FILENAME_OPML = "openmindmap.opml";
+
+function downloadFile(filename, data, type = "application/json") {
+  const blob = new Blob([data], { type });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+export default function App() {
+  const [nodes, setNodes] = useState(INITIAL_NODES);
+  const fileInputRef = useRef(null);
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY);
+      if (!stored) {
+        return;
+      }
+      const parsed = deserializeFromJSON(stored);
+      if (parsed?.length) {
+        setNodes(parsed);
+      }
+    } catch (error) {
+      console.warn("Impossible de charger les données, utilisation des valeurs par défaut.", error);
+      setNodes(INITIAL_NODES);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    try {
+      const payload = serializeToJSON(nodes);
+      window.localStorage.setItem(STORAGE_KEY, payload);
+    } catch (error) {
+      console.warn("Impossible de sauvegarder les données dans localStorage.", error);
+    }
+  }, [nodes]);
+
+  const handleExportJSON = useCallback(() => {
+    const payload = serializeToJSON(nodes);
+    downloadFile(DOWNLOAD_FILENAME_JSON, payload, "application/json");
+  }, [nodes]);
+
+  const handleExportOPML = useCallback(() => {
+    const payload = serializeToOPML(nodes);
+    downloadFile(DOWNLOAD_FILENAME_OPML, payload, "text/xml");
+  }, [nodes]);
+
+  const handleImport = useCallback(async (event) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    try {
+      const text = await file.text();
+      let imported;
+      if (file.name.toLowerCase().endsWith(".opml")) {
+        imported = deserializeFromOPML(text);
+      } else {
+        imported = deserializeFromJSON(text);
+      }
+      if (imported?.length) {
+        setNodes(imported);
+      }
+    } catch (error) {
+      console.error("Erreur lors de l'import du fichier.", error);
+    } finally {
+      event.target.value = "";
+    }
+  }, []);
+
+  const handleTriggerImport = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const totalNodes = useMemo(() => {
+    const countNodes = (items) =>
+      items.reduce(
+        (acc, item) => acc + 1 + (item.children ? countNodes(item.children) : 0),
+        0
+      );
+    return countNodes(nodes);
+  }, [nodes]);
+
+  return (
+    <div className="app">
+      <header className="app__header">
+        <div className="app__metrics">
+          <strong>Total de nœuds :</strong> {totalNodes}
+        </div>
+        <div className="app__actions">
+          <button type="button" onClick={handleExportJSON}>
+            Exporter (JSON)
+          </button>
+          <button type="button" onClick={handleExportOPML}>
+            Exporter (OPML)
+          </button>
+          <button type="button" onClick={handleTriggerImport}>
+            Importer
+          </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="application/json,.json,text/xml,.opml"
+            style={{ display: "none" }}
+            onChange={handleImport}
+          />
+        </div>
+      </header>
+      <main>
+        <pre>{JSON.stringify(nodes, null, 2)}</pre>
+      </main>
+    </div>
+  );
+}

--- a/src/utils/serialization.js
+++ b/src/utils/serialization.js
@@ -1,0 +1,92 @@
+const EXPORT_TITLE = "OpenMindMap Export";
+
+const ensureArray = (value) => {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  return [];
+};
+
+const normaliseNode = (node) => ({
+  id: String(node.id ?? ""),
+  label: String(node.label ?? ""),
+  children: ensureArray(node.children).map(normaliseNode),
+});
+
+export function serializeToJSON(nodes) {
+  return JSON.stringify(ensureArray(nodes).map(normaliseNode), null, 2);
+}
+
+export function deserializeFromJSON(text) {
+  if (!text) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(text);
+    return ensureArray(parsed).map(normaliseNode);
+  } catch (error) {
+    console.error("Impossible de parser le JSON fourni.", error);
+    throw error;
+  }
+}
+
+const escapeXml = (value) =>
+  String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+
+const nodesToOutline = (nodes, depth = 4) => {
+  const indent = (size) => " ".repeat(size);
+  return ensureArray(nodes)
+    .map((node) => {
+      const children = node.children?.length
+        ? `\n${nodesToOutline(node.children, depth + 2)}${indent(depth)}`
+        : "";
+      return `${indent(depth)}<outline text="${escapeXml(node.label)}" id="${escapeXml(
+        node.id
+      )}">${children}</outline>`;
+    })
+    .join("\n");
+};
+
+export function serializeToOPML(nodes) {
+  const body = nodesToOutline(ensureArray(nodes));
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<opml version="2.0">\n  <head>\n    <title>${escapeXml(
+    EXPORT_TITLE
+  )}</title>\n  </head>\n  <body>\n${body ? `${body}\n` : ""}  </body>\n</opml>`;
+}
+
+function parseXmlDocument(text) {
+  const parser = typeof DOMParser !== "undefined" ? new DOMParser() : null;
+  if (!parser) {
+    throw new Error("DOMParser est indisponible dans cet environnement");
+  }
+  const doc = parser.parseFromString(text, "text/xml");
+  const parserError = doc.querySelector("parsererror");
+  if (parserError) {
+    throw new Error(parserError.textContent ?? "Erreur de parsing OPML");
+  }
+  return doc;
+}
+
+const parseOutline = (element) => {
+  const id = element.getAttribute("id") ?? element.getAttribute("_uid") ?? "";
+  const label = element.getAttribute("text") ?? element.getAttribute("title") ?? "";
+  const children = Array.from(element.children)
+    .filter((child) => child.tagName?.toLowerCase() === "outline")
+    .map(parseOutline);
+  return normaliseNode({ id, label, children });
+};
+
+export function deserializeFromOPML(text) {
+  if (!text) {
+    return [];
+  }
+  const doc = parseXmlDocument(text);
+  const outlines = Array.from(doc.querySelectorAll("body > outline"));
+  return outlines.map(parseOutline);
+}


### PR DESCRIPTION
## Summary
- load node state from localStorage on mount with a fallback to the default map
- add an action toolbar to export JSON/OPML and trigger imports
- centralize serialization helpers and document supported formats in the README

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68de7d74d910832198a549ec19b57862