### PR TITLE
Fix SVG markup duplication in node rendering

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -643,52 +643,11 @@ function App() {
 
                     {isSelected && (
                       <foreignObject x={NODE_WIDTH / 2 + 12} y={-22} width={44} height={44}>
-                        <div className="quick-add" xmlns="http://www.w3.org/1999/xhtml">
-                          <button
-                            type="button"
-                            className="quick-add-button"
-                            data-no-drag="true"
-                            onClick={(event) => {
-                              event.stopPropagation()
-                              addChild()
-                            }}
-                          >
-                            +
-                          </button>
-                        </div>
-                      </foreignObject>
-                    )}
-                  </g>
-                )
-              })}
-            </g>
-          </g>
-
-                      >
-                        {isSelected ? (
-                          <input
-                            className="node-input"
-                            autoFocus
-                            value={draftLabel}
-                            placeholder="Nommez cette idée"
-                            onChange={(event) => updateSelectedLabel(event.target.value)}
-                            onClick={(event) => event.stopPropagation()}
-                            onKeyDown={handleNodeKeyDown}
-                          />
-                        ) : (
-                          <span className={`node-label ${displayLabel === node.label ? '' : 'is-placeholder'}`}>
-                            {displayLabel}
-                          </span>
-                        )}
-                      </div>
-                    </foreignObject>
-
-                    {isSelected && (
-                      <foreignObject x={NODE_WIDTH / 2 + 12} y={-22} width={44} height={44}>
                         <div className="quick-add" data-pan-stop="true" xmlns="http://www.w3.org/1999/xhtml">
                           <button
                             type="button"
                             className="quick-add-button"
+                            data-no-drag="true"
                             onClick={(event) => {
                               event.stopPropagation()
                               addChild()


### PR DESCRIPTION
## Summary
- remove duplicated SVG markup that caused build failure in the mind map node renderer
- restore the quick add button to use the IconPlus glyph while preserving drag-prevention attributes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de8c248c1c832180cb76a003f7b6b3