### PR TITLE
feat: add local persistence for mind map

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -246,16 +246,7 @@
   background: linear-gradient(135deg, #7c3aed 0%, #4f46e5 100%);
 }
 
-.overlay-button--danger {
-  background: linear-gradient(135deg, #f97316 0%, #ef4444 100%);
-  color: white;
-}
-
-.overlay-button--danger:hover {
-  background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
-}
-
-.autosave-info {
+.save-status {
   background: rgba(15, 23, 42, 0.72);
   color: white;
   padding: 10px 16px;

--- a/src/App.css
+++ b/src/App.css
@@ -190,22 +190,24 @@
 
 .canvas-overlay {
   position: absolute;
-  bottom: 24px;
-  left: 50%;
-  transform: translateX(-50%);
+  top: 24px;
+  left: 24px;
+  z-index: 2;
 }
 
 .overlay-panel {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  align-items: center;
+  gap: 14px;
+  align-items: flex-start;
 }
 
 .overlay-actions {
   display: flex;
   align-items: center;
   gap: 10px;
+  flex-wrap: wrap;
+  justify-content: flex-start;
 }
 
 .overlay-button {
@@ -245,6 +247,15 @@
 
 .overlay-button--primary:hover {
   background: linear-gradient(135deg, #0ea5e9 0%, #0284c7 100%);
+}
+
+.overlay-button--secondary {
+  background: linear-gradient(135deg, #a855f7 0%, #6366f1 100%);
+  color: white;
+}
+
+.overlay-button--secondary:hover {
+  background: linear-gradient(135deg, #7c3aed 0%, #4f46e5 100%);
 }
 
 .overlay-button--danger {

--- a/src/App.css
+++ b/src/App.css
@@ -202,6 +202,70 @@
   align-items: center;
 }
 
+.overlay-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.overlay-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border: none;
+  border-radius: 999px;
+  padding: 10px 18px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: rgba(255, 255, 255, 0.94);
+  color: #0f172a;
+  box-shadow: 0 18px 35px rgba(15, 23, 42, 0.18);
+  transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.2s ease;
+}
+
+.overlay-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 22px 45px rgba(15, 23, 42, 0.22);
+}
+
+.overlay-button:active {
+  transform: translateY(0);
+}
+
+.overlay-button:focus-visible {
+  outline: 2px solid #38bdf8;
+  outline-offset: 2px;
+}
+
+.overlay-button--primary {
+  background: linear-gradient(135deg, #38bdf8 0%, #0ea5e9 100%);
+  color: white;
+}
+
+.overlay-button--primary:hover {
+  background: linear-gradient(135deg, #0ea5e9 0%, #0284c7 100%);
+}
+
+.overlay-button--danger {
+  background: linear-gradient(135deg, #f97316 0%, #ef4444 100%);
+  color: white;
+}
+
+.overlay-button--danger:hover {
+  background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
+}
+
+.autosave-info {
+  background: rgba(15, 23, 42, 0.72);
+  color: white;
+  padding: 10px 16px;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  letter-spacing: 0.01em;
+  box-shadow: 0 18px 35px rgba(15, 23, 42, 0.2);
+}
+
 .grid-toggle {
   display: inline-flex;
   align-items: center;

--- a/src/App.css
+++ b/src/App.css
@@ -18,18 +18,6 @@
   user-select: none;
 }
 
-.canvas-wrapper.with-grid::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background-image:
-    linear-gradient(rgba(15, 23, 42, 0.12) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(15, 23, 42, 0.12) 1px, transparent 1px);
-  background-size: 40px 40px;
-  pointer-events: none;
-  opacity: 0.45;
-}
-
 .mindmap-canvas {
   width: 100%;
   height: 100%;
@@ -277,34 +265,3 @@
   box-shadow: 0 18px 35px rgba(15, 23, 42, 0.2);
 }
 
-.grid-toggle {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  background: rgba(15, 23, 42, 0.78);
-  color: white;
-  padding: 10px 16px;
-  border-radius: 999px;
-  font-size: 0.85rem;
-  font-weight: 600;
-  letter-spacing: 0.01em;
-  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.25);
-  cursor: pointer;
-  user-select: none;
-}
-
-.grid-toggle input {
-  width: 18px;
-  height: 18px;
-  accent-color: #38bdf8;
-}
-
-.overlay-tip {
-  background: rgba(15, 23, 42, 0.75);
-  color: white;
-  padding: 10px 16px;
-  border-radius: 999px;
-  font-size: 0.85rem;
-  letter-spacing: 0.01em;
-  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.2);
-}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -847,13 +847,11 @@ function App() {
               onChange={handleImportFromFile}
               style={{ display: 'none' }}
             />
-            <div className="save-status">
-              {formattedLastSavedAt ? (
+            {formattedLastSavedAt && (
+              <div className="save-status">
                 <span>Dernière sauvegarde : {formattedLastSavedAt}</span>
-              ) : (
-                <span>Aucune sauvegarde effectuée</span>
-              )}
-            </div>
+              </div>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- persist mind map nodes, layout, and settings locally with autosave and manual save support
- restore saved maps on load, clear stale positions, and provide a reset flow to start from scratch
- add UI controls for saving/resetting and display the timestamp of the last local save

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de8e630420832184ae4471eade5044