### PR TITLE
Fix node styling around note cards

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -76,19 +76,17 @@
   font-size: 1.05rem;
   text-align: center;
   line-height: 1.3;
-  border: 3px solid transparent;
+  border: 5px solid #000;
   box-shadow: 0 20px 45px rgba(15, 23, 42, 0.18);
   transition: border 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
-  filter: url(#node-shadow);
 }
 
 .mindmap-node-card.is-selected {
-  border-color: #38bdf8;
   box-shadow: 0 25px 50px rgba(14, 165, 233, 0.25);
 }
 
 .mindmap-node-card.is-root {
-  border-color: #2563eb;
+  box-shadow: 0 28px 55px rgba(37, 99, 235, 0.25);
 }
 
 .node-input {


### PR DESCRIPTION
## Summary
- remove the drop-shadow filter so nodes no longer show a grey rectangular background
- add a bold black border to each node and adjust highlight shadows for selected/root states

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68deaaed53a08321a1f84cc2e4404064