### PR TITLE
feat: auto resize nodes based on content

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -78,7 +78,7 @@
   line-height: 1.3;
   border: 3px solid transparent;
   box-shadow: 0 20px 45px rgba(15, 23, 42, 0.18);
-  transition: border 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+  transition: border 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease, width 0.18s ease, height 0.18s ease;
   filter: url(#node-shadow);
 }
 
@@ -109,6 +109,8 @@
 .node-label {
   display: inline-block;
   padding: 0 4px;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .node-label.is-placeholder {


### PR DESCRIPTION
## Summary
- measure node labels in the browser to compute adaptive SVG node widths and heights
- render nodes and toolbars with the computed dimensions and allow wrapped labels without overflow
- tweak styles so node labels wrap cleanly and resizing transitions remain smooth

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dea9f7cc288321a3906e9f0a8f3371