### PR TITLE
Rename application to Open Mind Map and add themed logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# 🌐 OpenMindMap — Proof of Concept
+# 🌐 Open Mind Map — Proof of Concept
 
-OpenMindMap est une première ébauche d’application de **mind mapping** collaborative. Ce proof of concept se concentre sur les briques essentielles pour manipuler visuellement une carte et structurer ses idées.
+Open Mind Map est une première ébauche d’application de **mind mapping** collaborative. Ce proof of concept se concentre sur les briques essentielles pour manipuler visuellement une carte et structurer ses idées.
 
 ## ✨ Fonctionnalités incluses
 
@@ -31,4 +31,4 @@ Puis ouvrez [http://localhost:5173](http://localhost:5173) pour découvrir l’i
 - Gestion avancée du contenu des nœuds (tags, dates, pièces jointes).
 - Export/import vers des formats standard (Markdown, OPML, JSON).
 
-Ce dépôt servira de base pour itérer vers une version complète d’OpenMindMap.
+Ce dépôt servira de base pour itérer vers une version complète d’Open Mind Map.

--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/open-mind-map-logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Open Mind Map</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "vite-react-starter",
+  "name": "open-mind-map",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "vite-react-starter",
+      "name": "open-mind-map",
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vite-react-starter",
+  "name": "open-mind-map",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/public/open-mind-map-logo.svg
+++ b/public/open-mind-map-logo.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" role="img" aria-labelledby="title desc">
+  <title id="title">Open Mind Map Logo</title>
+  <desc id="desc">Central idea node connected to surrounding thoughts in a gradient circle.</desc>
+  <defs>
+    <linearGradient id="coreGradient" x1="0%" x2="100%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#38bdf8" />
+      <stop offset="100%" stop-color="#6366f1" />
+    </linearGradient>
+    <linearGradient id="orbitGradient" x1="0%" x2="100%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="rgba(148, 163, 184, 0.35)" />
+      <stop offset="100%" stop-color="rgba(79, 70, 229, 0.4)" />
+    </linearGradient>
+    <filter id="shadow" x="-30%" y="-30%" width="160%" height="160%" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="4" stdDeviation="5" flood-color="rgba(15, 23, 42, 0.25)" />
+    </filter>
+  </defs>
+  <rect width="96" height="96" rx="24" fill="#f8fafc" />
+  <g transform="translate(48 48)" stroke-linecap="round" stroke-linejoin="round">
+    <circle r="34" fill="url(#orbitGradient)" opacity="0.35" />
+    <g stroke="#1e293b" stroke-width="3.6" fill="none">
+      <path d="M 0 -18 L 0 -34" />
+      <path d="M -15 -6 L -30 -16" />
+      <path d="M 17 -2 L 30 -12" />
+      <path d="M 12 10 L 26 22" />
+      <path d="M -8 14 L -22 26" />
+    </g>
+    <g fill="#0f172a">
+      <circle cx="0" cy="-38" r="5" />
+      <circle cx="-34" cy="-20" r="6" />
+      <circle cx="34" cy="-14" r="6" />
+      <circle cx="32" cy="24" r="6" />
+      <circle cx="-26" cy="30" r="6" />
+    </g>
+    <g filter="url(#shadow)">
+      <circle r="18" fill="url(#coreGradient)" />
+      <circle r="18" fill="url(#coreGradient)" opacity="0.32" />
+      <circle r="10" fill="#ffffff" opacity="0.55" />
+    </g>
+  </g>
+</svg>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,7 +10,7 @@ const PLACEHOLDER_LABEL = 'Nommez cette idée'
 const DEFAULT_NODE_SIZE = Object.freeze({ width: MIN_NODE_WIDTH, height: MIN_NODE_HEIGHT })
 
 const INITIAL_NODES = [
-  { id: 'root', label: 'Ma carte mentale', parentId: null },
+  { id: 'root', label: 'Open Mind Map', parentId: null },
   { id: 'node-1', label: 'Idée clé #1', parentId: 'root' },
   { id: 'node-2', label: 'Idée clé #2', parentId: 'root' },
 ]


### PR DESCRIPTION
## Summary
- rename the project to "Open Mind Map" across the UI, documentation, and package metadata
- add a custom Open Mind Map SVG favicon and set it as the app icon
- update the default root node label to reflect the new product name

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68deb17b1ad48321a4033633e3ac3476