### PR TITLE
Move save/load controls to top left

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -18,18 +18,6 @@
   user-select: none;
 }
 
-.canvas-wrapper.with-grid::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background-image:
-    linear-gradient(rgba(15, 23, 42, 0.12) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(15, 23, 42, 0.12) 1px, transparent 1px);
-  background-size: 40px 40px;
-  pointer-events: none;
-  opacity: 0.45;
-}
-
 .mindmap-canvas {
   width: 100%;
   height: 100%;
@@ -191,46 +179,38 @@
 
 .canvas-overlay {
   position: absolute;
-  bottom: 24px;
-  left: 50%;
-  transform: translateX(-50%);
+  top: 24px;
+  left: 24px;
 }
 
 .overlay-panel {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  align-items: center;
+  align-items: flex-start;
 }
 
-.grid-toggle {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
+.overlay-actions {
+  display: flex;
+  gap: 12px;
+}
+
+.overlay-button {
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: none;
   background: rgba(15, 23, 42, 0.78);
   color: white;
-  padding: 10px 16px;
-  border-radius: 999px;
   font-size: 0.85rem;
   font-weight: 600;
   letter-spacing: 0.01em;
-  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.25);
   cursor: pointer;
-  user-select: none;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.2);
+  transition: background 0.2s ease, transform 0.2s ease;
 }
 
-.grid-toggle input {
-  width: 18px;
-  height: 18px;
-  accent-color: #38bdf8;
+.overlay-button:hover {
+  background: rgba(59, 130, 246, 0.92);
+  transform: translateY(-1px);
 }
 
-.overlay-tip {
-  background: rgba(15, 23, 42, 0.75);
-  color: white;
-  padding: 10px 16px;
-  border-radius: 999px;
-  font-size: 0.85rem;
-  letter-spacing: 0.01em;
-  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.2);
-}


### PR DESCRIPTION
## Summary
- reposition the save/load toolbar to the top-left overlay and remove unused helper text
- drop the grid snapping toggle and related persistence logic from the interface
- simplify styles now that the overlay only contains the save/load actions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68deb14f4fd883218537c2ba853f7bf0