### PR TITLE
Add PDF export option for mind map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "open-mind-map",
       "version": "0.0.0",
       "dependencies": {
+        "jspdf": "^3.0.3",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -255,6 +256,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1377,6 +1387,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/react": {
       "version": "19.2.0",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.0.tgz",
@@ -1396,6 +1419,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.0.4",
@@ -1488,6 +1518,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.10",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.10.tgz",
@@ -1574,6 +1614,26 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1625,6 +1685,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.45.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.45.1.tgz",
+      "integrity": "sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1638,6 +1710,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/csstype": {
@@ -1671,6 +1753,16 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.228",
@@ -1943,6 +2035,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1960,6 +2063,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -2073,6 +2182,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2109,6 +2232,12 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -2205,6 +2334,23 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.3.tgz",
+      "integrity": "sha512-eURjAyz5iX1H8BOYAfzvdPfIKK53V7mCpBTe7Kb16PaM8JSXEcUQNBQaiWMI8wY5RvNOPj4GccMjTlfwRBd+oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.9",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.2.4",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/keyv": {
@@ -2367,6 +2513,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -2399,6 +2551,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2469,6 +2628,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
@@ -2500,6 +2669,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2508,6 +2684,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rollup": {
@@ -2601,6 +2787,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -2625,6 +2821,26 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/tinyglobby": {
@@ -2696,6 +2912,16 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "jspdf": "^3.0.3",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,14 +32,14 @@ function getNextIdFromNodes(nodes) {
   )
 }
 
-function getDefaultFilename(label) {
+function getDefaultFilename(label, extension = 'json') {
   const fallback = 'mindmap'
   if (!label || typeof label !== 'string') {
-    return `${fallback}.json`
+    return `${fallback}.${extension}`
   }
   const trimmed = label.trim()
   if (trimmed.length === 0) {
-    return `${fallback}.json`
+    return `${fallback}.${extension}`
   }
   const normalized = trimmed
     .normalize('NFD')
@@ -49,7 +49,7 @@ function getDefaultFilename(label) {
     .replace(/-+/g, '-')
     .replace(/^-+|-+$/g, '')
   const safeName = normalized.length > 0 ? normalized : fallback
-  return `${safeName}.json`
+  return `${safeName}.${extension}`
 }
 
 function computeLayout(nodes) {
@@ -640,6 +640,147 @@ function App() {
     URL.revokeObjectURL(url)
   }, [customPositions, nodes, rootNode?.label, viewTransform])
 
+  const handleExportPdf = useCallback(async () => {
+    if (typeof window === 'undefined') return
+    try {
+      const { jsPDF } = await import('jspdf')
+      const pdf = new jsPDF({ orientation: 'landscape', unit: 'mm', format: 'a3' })
+      const pageWidth = pdf.internal.pageSize.getWidth()
+      const pageHeight = pdf.internal.pageSize.getHeight()
+      const margin = 20
+
+      const nodesWithPosition = nodes
+        .map((node) => {
+          const position = positions[node.id]
+          if (!position) return null
+          const size = nodeSizes[node.id] ?? DEFAULT_NODE_SIZE
+          return { node, position, size }
+        })
+        .filter(Boolean)
+
+      if (nodesWithPosition.length === 0) {
+        window.alert('Aucun contenu à exporter pour le PDF.')
+        return
+      }
+
+      let minX = Infinity
+      let maxX = -Infinity
+      let minY = Infinity
+      let maxY = -Infinity
+
+      nodesWithPosition.forEach(({ position, size }) => {
+        const halfWidth = size.width / 2
+        const halfHeight = size.height / 2
+        minX = Math.min(minX, position.x - halfWidth)
+        maxX = Math.max(maxX, position.x + halfWidth)
+        minY = Math.min(minY, position.y - halfHeight)
+        maxY = Math.max(maxY, position.y + halfHeight)
+      })
+
+      nodes.forEach((node) => {
+        if (node.parentId === null) return
+        const parentPosition = positions[node.parentId]
+        const nodePosition = positions[node.id]
+        if (!parentPosition || !nodePosition) return
+        minX = Math.min(minX, parentPosition.x, nodePosition.x)
+        maxX = Math.max(maxX, parentPosition.x, nodePosition.x)
+        minY = Math.min(minY, parentPosition.y, nodePosition.y)
+        maxY = Math.max(maxY, parentPosition.y, nodePosition.y)
+      })
+
+      if (!Number.isFinite(minX) || !Number.isFinite(maxX) || !Number.isFinite(minY) || !Number.isFinite(maxY)) {
+        window.alert('Impossible de déterminer la zone à exporter.')
+        return
+      }
+
+      const contentWidth = Math.max(maxX - minX, 1)
+      const contentHeight = Math.max(maxY - minY, 1)
+
+      const availableWidth = pageWidth - margin * 2
+      const availableHeight = pageHeight - margin * 2
+      const scale = Math.min(availableWidth / contentWidth, availableHeight / contentHeight)
+
+      const contentWidthScaled = contentWidth * scale
+      const contentHeightScaled = contentHeight * scale
+      const offsetX = margin + (availableWidth - contentWidthScaled) / 2
+      const offsetY = margin + (availableHeight - contentHeightScaled) / 2
+
+      const convertX = (value) => offsetX + (value - minX) * scale
+      const convertY = (value) => offsetY + (value - minY) * scale
+
+      pdf.setLineJoin('round')
+      pdf.setLineCap('round')
+      pdf.setDrawColor(15, 23, 42)
+
+      const connectionWidth = 3 * scale
+      pdf.setLineWidth(connectionWidth)
+      nodes.forEach((node) => {
+        if (node.parentId === null) return
+        const parentPosition = positions[node.parentId]
+        const nodePosition = positions[node.id]
+        if (!parentPosition || !nodePosition) return
+        pdf.line(convertX(parentPosition.x), convertY(parentPosition.y), convertX(nodePosition.x), convertY(nodePosition.y))
+      })
+
+      const PT_PER_MM = 72 / 25.4
+      const baseFontSizePx = 16.8
+      const lineHeightFactor = 1.3
+
+      nodesWithPosition.forEach(({ node, position, size }) => {
+        const nodeWidth = size.width * scale
+        const nodeHeight = size.height * scale
+        const nodeX = convertX(position.x - size.width / 2)
+        const nodeY = convertY(position.y - size.height / 2)
+        const cornerRadius = 24 * scale
+
+        const shadowOffset = 12 * scale
+        if (typeof pdf.GState === 'function') {
+          const shadowState = pdf.GState({ opacity: 0.18 })
+          pdf.setGState(shadowState)
+          pdf.setFillColor(15, 23, 42)
+          pdf.roundedRect(nodeX + shadowOffset, nodeY + shadowOffset, nodeWidth, nodeHeight, cornerRadius, cornerRadius, 'F')
+          pdf.setGState(pdf.GState({ opacity: 1 }))
+        }
+
+        pdf.setFillColor(255, 255, 255)
+        pdf.setDrawColor(0, 0, 0)
+        pdf.setLineWidth(5 * scale)
+        pdf.roundedRect(nodeX, nodeY, nodeWidth, nodeHeight, cornerRadius, cornerRadius, 'FD')
+
+        const paddingX = 20 * scale
+        const textAreaWidth = Math.max(nodeWidth - paddingX * 2, 0)
+        const centerX = nodeX + nodeWidth / 2
+        const centerY = nodeY + nodeHeight / 2
+
+        const label = node.label.trim().length > 0 ? node.label : PLACEHOLDER_LABEL
+        const fontSizePt = Math.max(baseFontSizePx * scale * PT_PER_MM, 6)
+        pdf.setFont('helvetica', 'bold')
+        const isPlaceholder = label === PLACEHOLDER_LABEL && node.label.trim().length === 0
+        if (isPlaceholder) {
+          pdf.setTextColor(94, 110, 135)
+        } else {
+          pdf.setTextColor(15, 23, 42)
+        }
+        pdf.setFontSize(fontSizePt)
+        const lines = pdf.splitTextToSize(label, textAreaWidth)
+        const lineHeight = (baseFontSizePx * lineHeightFactor * scale)
+        const totalHeight = lineHeight * lines.length
+        let startY = centerY - totalHeight / 2 + lineHeight / 2
+
+        lines.forEach((line) => {
+          pdf.text(line, centerX, startY, { align: 'center', baseline: 'middle' })
+          startY += lineHeight
+        })
+      })
+
+      const filename = getDefaultFilename(rootNode?.label, 'pdf')
+      pdf.save(filename)
+    } catch (error) {
+      console.error('Failed to export PDF', error)
+      window.alert("L'export PDF a échoué. Veuillez réessayer.")
+    }
+  }, [nodeSizes, nodes, positions, rootNode?.label])
+
   const handleLoadClick = useCallback(() => {
     fileInputRef.current?.click()
   }, [])
@@ -867,6 +1008,9 @@ function App() {
               </button>
               <button type="button" className="overlay-button" onClick={handleLoadClick} data-pan-stop="true">
                 Charger
+              </button>
+              <button type="button" className="overlay-button" onClick={handleExportPdf} data-pan-stop="true">
+                Exporter en PDF (A3)
               </button>
               <input
                 ref={fileInputRef}


### PR DESCRIPTION
## Summary
- add a reusable filename helper that supports multiple file extensions
- integrate jsPDF and implement an A3 landscape export pipeline that draws nodes and connectors as vector shapes and text
- expose the new Exporter en PDF (A3) action in the canvas toolbar

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68deb61a951c8321a8a9de40184315c0