### PR TITLE
Add configuration iframe for node editing

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -214,3 +214,32 @@
   transform: translateY(-1px);
 }
 
+.config-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 50;
+  backdrop-filter: blur(6px);
+}
+
+.config-iframe-wrapper {
+  width: min(640px, 92vw);
+  height: min(480px, 85vh);
+  border-radius: 32px;
+  box-shadow: 0 32px 70px rgba(15, 23, 42, 0.32);
+  overflow: hidden;
+  background: transparent;
+}
+
+.config-iframe {
+  width: 100%;
+  height: 100%;
+  border: none;
+  display: block;
+  background: transparent;
+}
+


### PR DESCRIPTION
## Summary
- add a modifier button to the floating toolbar that opens a configuration iframe
- implement iframe messaging to save or cancel text edits and update the selected node
- style the centered modal overlay to highlight the configuration space for future tools

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68deb8a5db9083218d9afb9fa8d23c3d